### PR TITLE
Update responsibility for invoking coroutine exception handlers

### DIFF
--- a/src/main/kotlin/ui/util/suspension/SuspendingFragment.kt
+++ b/src/main/kotlin/ui/util/suspension/SuspendingFragment.kt
@@ -2,6 +2,7 @@ package edu.erittenhouse.gitlabtimetracker.ui.util.suspension
 
 import javafx.scene.Node
 import tornadofx.Fragment
+import kotlin.coroutines.CoroutineContext
 
 abstract class SuspendingFragment private constructor(
     title: String?,
@@ -23,4 +24,5 @@ abstract class SuspendingFragment private constructor(
     }
     override fun registerBackgroundTaskInit(backgroundTaskInitFunction: () -> Unit) = scopeImpl.registerBackgroundTaskInit(backgroundTaskInitFunction)
     override fun registerBackgroundTaskCleanup(backgroundTaskCleanupFunction: () -> Unit) = scopeImpl.registerBackgroundTaskCleanup(backgroundTaskCleanupFunction)
+    override fun registerCoroutineExceptionHandler(coroutineExceptionHandleFunction: (CoroutineContext, Throwable) -> Unit) = scopeImpl.registerCoroutineExceptionHandler(coroutineExceptionHandleFunction)
 }

--- a/src/main/kotlin/ui/util/suspension/SuspendingItemFragment.kt
+++ b/src/main/kotlin/ui/util/suspension/SuspendingItemFragment.kt
@@ -1,6 +1,7 @@
 package edu.erittenhouse.gitlabtimetracker.ui.util.suspension
 
 import tornadofx.ItemFragment
+import kotlin.coroutines.CoroutineContext
 
 abstract class SuspendingItemFragment<T> private constructor(
     private val scopeImpl: UIScopeImpl
@@ -21,4 +22,5 @@ abstract class SuspendingItemFragment<T> private constructor(
     }
     override fun registerBackgroundTaskInit(backgroundTaskInitFunction: () -> Unit) = scopeImpl.registerBackgroundTaskInit(backgroundTaskInitFunction)
     override fun registerBackgroundTaskCleanup(backgroundTaskCleanupFunction: () -> Unit) = scopeImpl.registerBackgroundTaskCleanup(backgroundTaskCleanupFunction)
+    override fun registerCoroutineExceptionHandler(coroutineExceptionHandleFunction: (CoroutineContext, Throwable) -> Unit) = scopeImpl.registerCoroutineExceptionHandler(coroutineExceptionHandleFunction)
 }

--- a/src/main/kotlin/ui/util/suspension/SuspendingListCellFragment.kt
+++ b/src/main/kotlin/ui/util/suspension/SuspendingListCellFragment.kt
@@ -1,6 +1,7 @@
 package edu.erittenhouse.gitlabtimetracker.ui.util.suspension
 
 import tornadofx.ListCellFragment
+import kotlin.coroutines.CoroutineContext
 
 abstract class SuspendingListCellFragment<T> private constructor(
     private val scopeImpl: UIScopeImpl
@@ -20,4 +21,5 @@ abstract class SuspendingListCellFragment<T> private constructor(
     }
     override fun registerBackgroundTaskInit(backgroundTaskInitFunction: () -> Unit) = scopeImpl.registerBackgroundTaskInit(backgroundTaskInitFunction)
     override fun registerBackgroundTaskCleanup(backgroundTaskCleanupFunction: () -> Unit) = scopeImpl.registerBackgroundTaskCleanup(backgroundTaskCleanupFunction)
+    override fun registerCoroutineExceptionHandler(coroutineExceptionHandleFunction: (CoroutineContext, Throwable) -> Unit) = scopeImpl.registerCoroutineExceptionHandler(coroutineExceptionHandleFunction)
 }

--- a/src/main/kotlin/ui/util/suspension/SuspendingView.kt
+++ b/src/main/kotlin/ui/util/suspension/SuspendingView.kt
@@ -2,6 +2,7 @@ package edu.erittenhouse.gitlabtimetracker.ui.util.suspension
 
 import javafx.scene.Node
 import tornadofx.View
+import kotlin.coroutines.CoroutineContext
 
 abstract class SuspendingView private constructor(
     title: String?,
@@ -23,4 +24,5 @@ abstract class SuspendingView private constructor(
     }
     override fun registerBackgroundTaskInit(backgroundTaskInitFunction: () -> Unit) = scopeImpl.registerBackgroundTaskInit(backgroundTaskInitFunction)
     override fun registerBackgroundTaskCleanup(backgroundTaskCleanupFunction: () -> Unit) = scopeImpl.registerBackgroundTaskCleanup(backgroundTaskCleanupFunction)
+    override fun registerCoroutineExceptionHandler(coroutineExceptionHandleFunction: (CoroutineContext, Throwable) -> Unit) = scopeImpl.registerCoroutineExceptionHandler(coroutineExceptionHandleFunction)
 }

--- a/src/main/kotlin/ui/view/IssueLookupView.kt
+++ b/src/main/kotlin/ui/view/IssueLookupView.kt
@@ -49,6 +49,10 @@ class IssueLookupView : SuspendingView() {
             statusMessage.set("")
             foundIssue.set(null)
         }
+
+        registerCoroutineExceptionHandler { _, exception ->
+            ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
+        }
     }
 
     override val root = vbox {
@@ -126,10 +130,5 @@ class IssueLookupView : SuspendingView() {
             }
 
         foundIssue.set(retrievedIssue)
-    }
-
-    override fun onUncaughtCoroutineException(context: CoroutineContext, exception: Throwable) {
-        super.onUncaughtCoroutineException(context, exception)
-        ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
     }
 }

--- a/src/main/kotlin/ui/view/settings/SlackSettingsSubview.kt
+++ b/src/main/kotlin/ui/view/settings/SlackSettingsSubview.kt
@@ -95,6 +95,10 @@ class SlackSettingsSubview : SuspendingView() {
                     }
             }
         }
+
+        registerCoroutineExceptionHandler { _, exception ->
+            errorMessageDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
+        }
     }
 
     override val root = vbox {
@@ -162,11 +166,6 @@ class SlackSettingsSubview : SuspendingView() {
                 }
             }
         }
-    }
-
-    override fun onUncaughtCoroutineException(context: CoroutineContext, exception: Throwable) {
-        super.onUncaughtCoroutineException(context, exception)
-        errorMessageDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
     }
 
     private suspend fun doSlackLogin() {

--- a/src/main/kotlin/ui/view/timetracking/FilterBarView.kt
+++ b/src/main/kotlin/ui/view/timetracking/FilterBarView.kt
@@ -48,6 +48,10 @@ class FilterBarView : SuspendingView() {
                 }
             }
         }
+
+        registerCoroutineExceptionHandler { _, exception ->
+            ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
+        }
     }
 
     override val root = hbox {
@@ -138,10 +142,5 @@ class FilterBarView : SuspendingView() {
                 }
             }
         }
-    }
-
-    override fun onUncaughtCoroutineException(context: CoroutineContext, exception: Throwable) {
-        super.onUncaughtCoroutineException(context, exception)
-        ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
     }
 }

--- a/src/main/kotlin/ui/view/timetracking/IssueListView.kt
+++ b/src/main/kotlin/ui/view/timetracking/IssueListView.kt
@@ -13,6 +13,12 @@ class IssueListView : SuspendingView() {
     private val issueController by inject<IssueController>()
     private val ioErrorDebouncer = Debouncer()
 
+    init {
+        registerCoroutineExceptionHandler { _, exception ->
+            ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
+        }
+    }
+
     override val root = vbox {
         style {
             maxWidth = 1000.px
@@ -30,10 +36,5 @@ class IssueListView : SuspendingView() {
                 vgrow = Priority.ALWAYS
             }
         }
-    }
-
-    override fun onUncaughtCoroutineException(context: CoroutineContext, exception: Throwable) {
-        super.onUncaughtCoroutineException(context, exception)
-        ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
     }
 }

--- a/src/main/kotlin/ui/view/timetracking/ProjectListView.kt
+++ b/src/main/kotlin/ui/view/timetracking/ProjectListView.kt
@@ -18,6 +18,12 @@ class ProjectListView : SuspendingView() {
     private val issueController by inject<IssueController>()
     private val ioErrorDebouncer = Debouncer()
 
+    init {
+        registerCoroutineExceptionHandler { _, exception ->
+            ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
+        }
+    }
+
     override val root = listview(projectController.projects) {
         vgrow = Priority.ALWAYS
         cellFragment(ProjectListCellFragment::class)
@@ -27,10 +33,5 @@ class ProjectListView : SuspendingView() {
                 is ProjectSelectResult.NoCredentials -> showErrorModal("Something's wrong, the time tracker couldn't read your credentials when pulling projects")
             }
         }
-    }
-
-    override fun onUncaughtCoroutineException(context: CoroutineContext, exception: Throwable) {
-        super.onUncaughtCoroutineException(context, exception)
-        ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
     }
 }

--- a/src/main/kotlin/ui/view/timetracking/TimeRecordingBarView.kt
+++ b/src/main/kotlin/ui/view/timetracking/TimeRecordingBarView.kt
@@ -27,6 +27,11 @@ class TimeRecordingBarView : SuspendingView() {
     private val issueController by inject<IssueController>()
     private val ioErrorDebouncer = Debouncer()
 
+    init {
+        registerCoroutineExceptionHandler { _, exception ->
+            ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
+        }
+    }
     override val root = hbox {
             addClass(LayoutStyles.typicalPaddingAndSpacing)
             alignment = Pos.CENTER
@@ -70,11 +75,6 @@ class TimeRecordingBarView : SuspendingView() {
                 }
             }
         }
-    }
-
-    override fun onUncaughtCoroutineException(context: CoroutineContext, exception: Throwable) {
-        super.onUncaughtCoroutineException(context, exception)
-        ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
     }
 
     private fun handleRecordingIssueUpdate(recordingState: TimeRecordingState) {

--- a/src/main/kotlin/ui/view/timetracking/TimeTrackingView.kt
+++ b/src/main/kotlin/ui/view/timetracking/TimeTrackingView.kt
@@ -97,6 +97,10 @@ class TimeTrackingView : SuspendingView("Gitlab Time Tracker") {
                 }
             }
         }
+
+        registerCoroutineExceptionHandler { _, exception ->
+            ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
+        }
     }
 
     override val root = borderpane {
@@ -126,11 +130,6 @@ class TimeTrackingView : SuspendingView("Gitlab Time Tracker") {
         }
 
         scopeBottom(TimeRecordingBarView::class)
-    }
-
-    override fun onUncaughtCoroutineException(context: CoroutineContext, exception: Throwable) {
-        super.onUncaughtCoroutineException(context, exception)
-        ioErrorDebouncer.runDebounced { showErrorModalForIOErrors(exception) }
     }
 
     private suspend fun listenForSettingsTrigger() {


### PR DESCRIPTION
Fixes #26

This updates the coroutine exception handler logic so both coroutines launched from init registrations and within the code itself will throw exceptions to the same place.